### PR TITLE
Rework functions so they are resolved at runtime

### DIFF
--- a/src/main/java/com/inksetter/twist/EvalContext.java
+++ b/src/main/java/com/inksetter/twist/EvalContext.java
@@ -1,10 +1,14 @@
 package com.inksetter.twist;
 
+import com.inksetter.twist.expression.function.TwistFunction;
+
 import java.util.Map;
 
 public interface EvalContext {
     boolean isDefined(String name);
     Object getVariable(String name);
     void setVariable(String name, Object value);
+    TwistFunction lookupFunction(String name);
+    void addFunction(String name, TwistFunction func);
     Map<String, Object> getAll();
 }

--- a/src/main/java/com/inksetter/twist/MapContext.java
+++ b/src/main/java/com/inksetter/twist/MapContext.java
@@ -1,15 +1,15 @@
 package com.inksetter.twist;
 
+import com.inksetter.twist.expression.function.TwistFunction;
+
 import java.util.LinkedHashMap;
 import java.util.Map;
 
 public class MapContext implements EvalContext {
     private final Map<String, Object> values;
+    private final Map<String, TwistFunction> functions = new LinkedHashMap<>();
     public MapContext() {
         values = new LinkedHashMap<>();
-    }
-    public MapContext(Map<String, Object> initial) {
-        values = initial;
     }
 
     @Override
@@ -30,5 +30,15 @@ public class MapContext implements EvalContext {
     @Override
     public Map<String, Object> getAll() {
         return values;
+    }
+
+    @Override
+    public TwistFunction lookupFunction(String name) {
+        return functions.get(name);
+    }
+
+    @Override
+    public void addFunction(String name, TwistFunction func) {
+        functions.put(name, func);
     }
 }

--- a/src/main/java/com/inksetter/twist/SimpleScriptContext.java
+++ b/src/main/java/com/inksetter/twist/SimpleScriptContext.java
@@ -1,19 +1,22 @@
 package com.inksetter.twist;
 
 import com.inksetter.twist.exec.ScriptContext;
+import com.inksetter.twist.expression.function.TwistFunction;
 
 import java.util.*;
 
 public class SimpleScriptContext implements ScriptContext {
 
     private final Deque<Map<String, Object>> varStack = new LinkedList<>();
+    private final Map<String, TwistFunction> functions = new HashMap<>();
 
     public SimpleScriptContext() {
         varStack.addFirst(new LinkedHashMap<>());
     }
 
-    public SimpleScriptContext(Map<String,Object> initial) {
+    public SimpleScriptContext(Map<String,Object> initial, Map<String, TwistFunction> functions) {
         varStack.addFirst(new LinkedHashMap<>(initial));
+        this.functions.putAll(functions);
     }
 
     @Override
@@ -63,4 +66,16 @@ public class SimpleScriptContext implements ScriptContext {
         varStack.forEach(vars::putAll);
         return vars;
     }
+
+    @Override
+    public TwistFunction lookupFunction(String name) {
+        return functions.get(name);
+    }
+
+    @Override
+    public void addFunction(String name, TwistFunction function) {
+        functions.put(name, function);
+    }
+
+
 }

--- a/src/main/java/com/inksetter/twist/TwistEngine.java
+++ b/src/main/java/com/inksetter/twist/TwistEngine.java
@@ -8,22 +8,6 @@ import java.util.HashMap;
 import java.util.Map;
 
 public class TwistEngine {
-    private final Map<String, TwistFunction> functions = new HashMap<>();
-
-    public TwistEngine(Map<String, TwistFunction> functions) {
-        this.functions.putAll(functions);
-    }
-
-    public TwistEngine() {
-    }
-
-    public void addFunction(String name, TwistFunction function) {
-        functions.put(name, function);
-    }
-
-    public TwistFunction lookupFunction(String name) {
-        return functions.get(name);
-    }
 
     public Expression parseExpression(String expr) throws TwistException {
         return new TwistParser(expr, this).parseExpression();

--- a/src/main/java/com/inksetter/twist/exec/DefFunctionStatement.java
+++ b/src/main/java/com/inksetter/twist/exec/DefFunctionStatement.java
@@ -1,0 +1,18 @@
+package com.inksetter.twist.exec;
+
+import com.inksetter.twist.TwistException;
+
+public class DefFunctionStatement implements Statement {
+    private final String name;
+    private final UserDefFunction function;
+    public DefFunctionStatement(String name, UserDefFunction function) {
+        this.name = name;
+        this.function = function;
+    }
+
+    @Override
+    public Object execute(ScriptContext exec) throws TwistException {
+        exec.addFunction(name ,function);
+        return null;
+    }
+}

--- a/src/main/java/com/inksetter/twist/exec/ScriptContext.java
+++ b/src/main/java/com/inksetter/twist/exec/ScriptContext.java
@@ -3,9 +3,12 @@
 package com.inksetter.twist.exec;
 
 import com.inksetter.twist.EvalContext;
+import com.inksetter.twist.expression.function.TwistFunction;
 
 public interface ScriptContext extends EvalContext {
     void popStack();
 
     void pushStack();
+
+    void addFunction(String name, TwistFunction function);
 }

--- a/src/main/java/com/inksetter/twist/expression/FunctionExpression.java
+++ b/src/main/java/com/inksetter/twist/expression/FunctionExpression.java
@@ -6,7 +6,9 @@ import com.inksetter.twist.TwistException;
 import com.inksetter.twist.expression.function.*;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * An expression that represents a function. Functions are evaluated
@@ -15,22 +17,30 @@ import java.util.List;
 public class FunctionExpression implements Expression {
     private final String name;
     private final List<Expression> args;
-    private final TwistFunction function;
 
-    public FunctionExpression(String name, List<Expression> args, TwistFunction function) {
+    public FunctionExpression(String name, List<Expression> args) {
         this.name = name;
         this.args = args;
-        this.function = function;
     }
     
     public Object evaluate(EvalContext ctx) throws TwistException {
+        TwistFunction func = BUILTINS.get(name.toLowerCase());
+
+        if (func == null) {
+            func = ctx.lookupFunction(name);
+        }
+
+        if (func == null) {
+            throw new TwistException("unrecognized function: " + name);
+        }
+
         List<Object> argValues = new ArrayList<>();
 
         for (Expression arg : args) {
             argValues.add(arg.evaluate(ctx));
         }
 
-        return function.invoke(argValues);
+        return func.invoke(argValues);
     }
     
     // @see java.lang.Object#toString()
@@ -53,4 +63,26 @@ public class FunctionExpression implements Expression {
         return tmp.toString();
     }
 
+    private final static Map<String, TwistFunction> BUILTINS = new HashMap<>();
+    static {
+        BUILTINS.put("date", new DateFunction());
+        BUILTINS.put("string", new StringFunction());
+        BUILTINS.put("int", new IntFunction());
+        BUILTINS.put("double", new DoubleFunction());
+        BUILTINS.put("upper", new UpperFunction());
+        BUILTINS.put("lower", new LowerFunction());
+        BUILTINS.put("trim", new TrimFunction());
+        BUILTINS.put("len", new LengthFunction());
+        BUILTINS.put("length", new LengthFunction());
+        BUILTINS.put("sprintf", new SprintfFunction());
+        BUILTINS.put("min", new MinFunction());
+        BUILTINS.put("max", new MaxFunction());
+        BUILTINS.put("substr", new SubstrFunction());
+        BUILTINS.put("indexof", new IndexOfFunction());
+        BUILTINS.put("eval", new EvalFunction());
+        BUILTINS.put("b64decode", new Base64DecodeFunction());
+        BUILTINS.put("b64encode", new Base64EncodeFunction());
+        BUILTINS.put("now", new NowFunction());
+        BUILTINS.put("type", new TypeFunction());
+    }
 }

--- a/src/main/java/com/inksetter/twist/expression/ReferenceExpression.java
+++ b/src/main/java/com/inksetter/twist/expression/ReferenceExpression.java
@@ -5,25 +5,28 @@ import com.inksetter.twist.TwistException;
 
 public class ReferenceExpression implements Assignable {
     public ReferenceExpression(String name) {
-        _name = name;
+        this.name = name;
     }
 
     @Override
     public Object evaluate(EvalContext ctx) {
-        return ctx.getVariable(_name);
+        return ctx.getVariable(name);
     }
 
     @Override
     public void assignValue(EvalContext exec, Object value) throws TwistException {
-        exec.setVariable(_name, value);
+        exec.setVariable(name, value);
     }
 
     // @see java.lang.Object#toString()
     @Override
     public String toString() {
-        return _name;
+        return name;
     }
 
-    private final String _name;
+    public String getName() {
+        return name;
+    }
 
+    private final String name;
 }

--- a/src/main/java/com/inksetter/twist/expression/function/EvalFunction.java
+++ b/src/main/java/com/inksetter/twist/expression/function/EvalFunction.java
@@ -5,10 +5,9 @@ import com.inksetter.twist.MapContext;
 import com.inksetter.twist.parser.TwistParser;
 
 /**
- * Casts the argument to a string.
+ * Evaluates the string as a TWIST expression.
  */
-public class JsonFunction extends SingleArgFunction {
-
+public class EvalFunction extends SingleArgFunction {
     @Override
     protected Object invoke(Object argValue) throws TwistException {
         return new TwistParser(argValue.toString()).parseExpression().evaluate(new MapContext());

--- a/src/main/java/com/inksetter/twist/expression/operators/compare/RegexFindExpression.java
+++ b/src/main/java/com/inksetter/twist/expression/operators/compare/RegexFindExpression.java
@@ -1,0 +1,25 @@
+package com.inksetter.twist.expression.operators.compare;
+
+import com.inksetter.twist.Expression;
+import com.inksetter.twist.expression.operators.AbsractOperExpression;
+
+import java.util.regex.Pattern;
+
+public class RegexFindExpression extends AbsractOperExpression {
+    public RegexFindExpression(Expression left, Expression right) {
+        super(left, right);
+    }
+    
+    protected Boolean doOper(Object left, Object right) {
+        String leftValue = String.valueOf(left);
+        String rightValue = String.valueOf(right);
+
+        Pattern regex = Pattern.compile(rightValue);
+        return regex.matcher(leftValue).find();
+    }
+    
+    @Override
+    protected String operString() {
+        return " =~ ";
+    }
+}

--- a/src/main/java/com/inksetter/twist/parser/TwistLexer.java
+++ b/src/main/java/com/inksetter/twist/parser/TwistLexer.java
@@ -282,12 +282,19 @@ public class TwistLexer {
                 if (hasNext() && peekChar() == '=') {
                     // This is to go over the = character
                     nextChar();
-                    return new TwistToken(TwistTokenType.EQ, begin, startOfToken);
+                    if (hasNext() && peekChar() == '~') {
+                        // This is to go over the = character
+                        nextChar();
+                        return new TwistToken(TwistTokenType.MATCH, begin, startOfToken);
+                    }
+                    else {
+                        return new TwistToken(TwistTokenType.EQ, begin, startOfToken);
+                    }
                 }
                 else if (hasNext() && peekChar() == '~') {
                     // This is to go over the = character
                     nextChar();
-                    return new TwistToken(TwistTokenType.MATCH, begin, startOfToken);
+                    return new TwistToken(TwistTokenType.FIND, begin, startOfToken);
                 }
                 else {
                     return new TwistToken(TwistTokenType.ASSIGNMENT, begin, startOfToken);

--- a/src/main/java/com/inksetter/twist/parser/TwistTokenType.java
+++ b/src/main/java/com/inksetter/twist/parser/TwistTokenType.java
@@ -18,7 +18,7 @@ public enum TwistTokenType {
     OPEN_BRACKET, CLOSE_BRACKET, COMMA,
 
     // operators
-    EQ, NE, LT, GT, LE, GE, MATCH, NMATCH,
+    EQ, NE, LT, GT, LE, GE, MATCH, FIND, NMATCH,
     BANG, AND, OR,
     STAR, PLUS, MINUS, SLASH, PERCENT,
     NOT, LIKE, QUESTION, COLON, ELVIS,

--- a/src/test/java/com/inksetter/twist/parser/TwistParserTest.java
+++ b/src/test/java/com/inksetter/twist/parser/TwistParserTest.java
@@ -7,6 +7,7 @@ import com.inksetter.twist.exec.StatementBlock;
 import com.inksetter.twist.Expression;
 import com.inksetter.twist.expression.AssignmentExpression;
 import com.inksetter.twist.expression.FunctionExpression;
+import com.inksetter.twist.expression.ReferenceExpression;
 import com.inksetter.twist.expression.StringLiteral;
 import com.inksetter.twist.expression.function.TwistFunction;
 import org.junit.Test;
@@ -72,7 +73,7 @@ public class TwistParserTest {
                 "b = callFunction(a, 'String');\n" +
                 "if (a == b && c != true) print('WOW');\n";
 
-        StatementBlock parsed = (StatementBlock) new TwistParser(script, new TwistEngine(functions)).parseScript();
+        StatementBlock parsed = (StatementBlock) new TwistParser(script).parseScript();
         List<Statement> statements = parsed.getStatements();
         assertEquals(3, statements.size());
     }
@@ -95,7 +96,7 @@ public class TwistParserTest {
         String script =
                 "a = 1000 * func('var' + b);" +
                 "func2(a);";
-        StatementBlock parsed = (StatementBlock) new TwistParser(script, new TwistEngine(functions)).parseScript();
+        StatementBlock parsed = (StatementBlock) new TwistParser(script).parseScript();
         List<Statement> statements = parsed.getStatements();
         assertEquals(2, statements.size());
         Statement statement = statements.get(0);
@@ -143,5 +144,23 @@ public class TwistParserTest {
         String result = ((StringLiteral) expr).evaluate(null);
 
         assertEquals(expected, result);
+    }
+
+    @Test
+    public void testBareWordFunction() throws ScriptSyntaxException {
+        Map<String, TwistFunction> functions = Map.of(
+                "func", args -> "call [" + args + "]",
+                "func2", args -> "call2 [" + args + "]");
+        String script = "func\n" +
+                "func2(1,2,3)";
+        StatementBlock parsed = (StatementBlock) new TwistParser(script).parseScript();
+        List<Statement> statements = parsed.getStatements();
+        assertEquals(2, statements.size());
+        Statement statement = statements.get(0);
+        Expression expr = ((ExpressionStatement)statement).getExpression();
+        assertTrue(expr instanceof ReferenceExpression);
+        Statement statement2 = statements.get(1);
+        Expression expr2 = ((ExpressionStatement)statement2).getExpression();
+        assertTrue(expr2 instanceof FunctionExpression);
     }
 }


### PR DESCRIPTION
Rework functions so they are resolved at runtime, not when a script is parsed. This makes the ScriptEngine class somewhat obsolete, but it could be used to add future enhancements, such as parse options, turning on/off behaviors, etc.